### PR TITLE
Allow object rest spread

### DIFF
--- a/base.js
+++ b/base.js
@@ -12,7 +12,7 @@ module.exports = {
   ],
   parserOptions: {
     ecmaFeatures: {
-      experimentalObjectRestSpread: false,
+      experimentalObjectRestSpread: true,
       jsx: false
     },
     ecmaVersion: 2015,

--- a/base.js
+++ b/base.js
@@ -12,10 +12,9 @@ module.exports = {
   ],
   parserOptions: {
     ecmaFeatures: {
-      experimentalObjectRestSpread: true,
       jsx: false
     },
-    ecmaVersion: 2015,
+    ecmaVersion: 2018,
     sourceType: 'script'
   },
   plugins: [


### PR DESCRIPTION
Object rest spread is support by the current NodeJS LTS version. More at [Node Green](https://node.green/#ES2018-features-object-rest-spread-properties)