### PR TITLE
Npm namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It is based on the ESLint recommended rules, the [JavaScript Standard style](htt
 ## Install
 
 ```bash
-npm install --save-dev eslint eslint-config-bloq eslint-config-standard eslint-plugin-import eslint-plugin-jsdoc eslint-plugin-mocha eslint-plugin-node eslint-plugin-prefer-arrow eslint-plugin-promise eslint-plugin-standard
+npm install --save-dev eslint @bloq/eslint-config eslint-config-standard eslint-plugin-import eslint-plugin-jsdoc eslint-plugin-mocha eslint-plugin-node eslint-plugin-prefer-arrow eslint-plugin-promise eslint-plugin-standard
 ```
 
 ## Configuration

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eslint-config-bloq",
+  "name": "@bloq/eslint-config",
   "version": "2.1.0",
   "description": "ESLint config to use at Bloq",
   "keywords": [


### PR DESCRIPTION
Lately, we have been using npm `@bloq` namespace for our libraries. It would be nice to use the same approach with this one.