### PR TITLE
Add no-return-assign rule

### DIFF
--- a/base.js
+++ b/base.js
@@ -30,6 +30,7 @@ module.exports = {
     'no-else-return': 'error',
     'no-multi-assign': 'error',
     'no-param-reassign': 'error',
+    'no-return-assign': ['error', 'always'],
     'no-shadow': [
       'error',
       { allow: ['err'], builtinGlobals: true, hoist: 'functions' }


### PR DESCRIPTION
This PR adds [no-return-assign](https://eslint.org/docs/rules/no-return-assign) rule - this should prevent errors like doing assignments in methods like `find()`, `some()`, etc