### PR TITLE
Enable no-console rule as error

### DIFF
--- a/base.js
+++ b/base.js
@@ -27,6 +27,7 @@ module.exports = {
     'consistent-return': 'error',
     'max-len': ['warn', { code: 80, ignoreComments: false, tabWidth: 2 }],
     'max-params': ['warn', 4],
+    'no-console': 'error',
     'no-else-return': 'error',
     'no-multi-assign': 'error',
     'no-param-reassign': 'error',


### PR DESCRIPTION
Enable the [no-console](https://eslint.org/docs/rules/no-console) eslint rule. I verified and it is not enabled by either `eslint:recommended`, `standard` nor by us, so it will be useful to have it enabled.