### PR TITLE
Update no-unused-vars to ignore rest siblings

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = {
     'no-param-reassign': 'warn',
     'no-return-assign': 'warn',
     'no-shadow': 'warn',
-    'no-unused-vars': 'error',
+    'no-unused-vars': ['error', { ignoreRestSiblings: true }],
     'no-use-before-define': 'error',
     'no-var': 'error',
     'object-shorthand': 'warn',


### PR DESCRIPTION
This PR updates the rule `no-unused-vars` to ignore the properties omitted when using rest parameters. [Here](https://eslint.org/docs/rules/no-unused-vars#ignorerestsiblings) are the docs of this property.

An example we have on Vesper that's throwing a linter error:

```js
lodash.mapValues(
  lodash.keyBy(chainsArray, 'chainId'),
  ({ chainId, ...data }) => data
)
```

here, we are removing `chainId` from the new object created. However, by default, this rule marks `chainId` as unused. This PR fixes that