### PR TITLE
Make mocha/no-exclusive-tests log error

### DIFF
--- a/mocha.js
+++ b/mocha.js
@@ -7,6 +7,7 @@ module.exports = {
   extends: ['plugin:mocha/recommended'],
   plugins: ['mocha', 'prefer-arrow'],
   rules: {
+    'mocha/no-exclusive-tests': 'error',
     'mocha/no-setup-in-describe': 'warn',
     'mocha/no-skipped-tests': 'warn',
     'no-unused-expressions': 'off',


### PR DESCRIPTION
Make [no-exclusive-tests](https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-exclusive-tests.md) to log an error instead of a warning.

This should prevent users from committing `.only` tests/suites