### PR TITLE
Enable sort-keys rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ module.exports = {
       { allowTemplateLiterals: false, avoidEscape: true }
     ],
     'require-jsdoc': 'off',
+    'sort-keys': ['warn', 'asc', { caseSensitive: false }],
     'strict': ['error', 'safe']
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-bloq",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-bloq",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Common ESLint config used at Bloq",
   "keywords": [
     "bloq",


### PR DESCRIPTION
This PR enables the [sort-keys rule](https://eslint.org/docs/latest/rules/sort-keys)  with all their default options, except for the `caseSensitive` one, so properties with capital letters, if any, don't go at the top of the lowercase ones.

It also upgrades the version (so a new version is published)

Closes #36 