### PR TITLE
Add natural sorting keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = {
       { allowTemplateLiterals: false, avoidEscape: true }
     ],
     'require-jsdoc': 'off',
-    'sort-keys': ['warn', 'asc', { caseSensitive: false }],
+    'sort-keys': ['warn', 'asc', { caseSensitive: false, natural: true }],
     'strict': ['error', 'safe']
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-config-bloq",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-config-bloq",
-      "version": "4.0.2",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "eslint-config-next": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-bloq",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "description": "Common ESLint config used at Bloq",
   "keywords": [
     "bloq",


### PR DESCRIPTION
This PR adds `natural: true`  to `sort-keys` rule, so number strings in properties are properly sorted as numbers. See [options for that rule](https://eslint.org/docs/latest/rules/sort-keys#options)