### PR TITLE
Add vitest plugin config

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Additional rule sets are available:
 - `bloq/next`
 - `bloq/node`
 - `bloq/typescript`
+- `bloq/vitest`
 
 ## Note on code formatting
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^8.11.0",
         "@typescript-eslint/parser": "^8.11.0",
+        "@vitest/eslint-plugin": "^1.1.7",
         "eslint-config-next": "^13.0.0",
         "eslint-config-prettier": "^8.0.0",
         "eslint-plugin-import": "^2.0.0",
@@ -523,6 +524,26 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
+    },
+    "node_modules/@vitest/eslint-plugin": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.1.7.tgz",
+      "integrity": "sha512-pTWGW3y6lH2ukCuuffpan6kFxG6nIuoesbhMiQxskyQMRcCN5t9SXsKrNHvEw3p8wcCsgJoRqFZVkOTn6TjclA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@typescript-eslint/utils": ">= 8.0",
+        "eslint": ">= 8.57.0",
+        "typescript": ">= 5.0.0",
+        "vitest": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.13.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "lint": "eslint --cache ."
   },
   "dependencies": {
+    "@typescript-eslint/eslint-plugin": "^8.11.0",
+    "@typescript-eslint/parser": "^8.11.0",
+    "@vitest/eslint-plugin": "^1.1.7",
     "eslint-config-next": "^13.0.0",
     "eslint-config-prettier": "^8.0.0",
     "eslint-plugin-import": "^2.0.0",
@@ -35,8 +38,6 @@
     "eslint-plugin-markdownlint": "^0.6.0",
     "eslint-plugin-mocha": "^10.0.0",
     "eslint-plugin-node": "^11.0.0",
-    "@typescript-eslint/eslint-plugin": "^8.11.0",
-    "@typescript-eslint/parser": "^8.11.0",
     "eslint-plugin-prefer-arrow": "^1.0.0",
     "eslint-plugin-promise": "^6.0.0"
   },

--- a/vitest.js
+++ b/vitest.js
@@ -1,0 +1,17 @@
+'use strict'
+
+module.exports = {
+  extends: ['plugin:@vitest/legacy-recommended'],
+  plugins: ['@vitest'],
+  rules: {
+    'no-unused-expressions': 'off',
+    'node/no-unpublished-require': 'warn',
+    'prefer-arrow/prefer-arrow-functions': 'off',
+    // equivalent to mocha/no-exclusive-tests
+    'vitest/no-focused-tests': 'error',
+    // equivalent to mocha/no-setup-in-describe
+    'vitest/require-hook': 'warn',
+    // equivalent to mocha/no-skipped-tests
+    'vitest/no-disabled-tests': 'error'
+  }
+}


### PR DESCRIPTION
This PR adds the eslint configuration for Vitest, which is useful as a test runner for projects with Typescript as Mocha has issues with its support (while vitest works out of the box)

The rule configuration mimics what is set for mocha. The plugin used is [@vitest/eslint-plugin](https://www.npmjs.com/package/@vitest/eslint-plugin)