### PR TITLE
Fix vitest config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-config-bloq",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-config-bloq",
-      "version": "4.4.0",
+      "version": "4.4.1",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^8.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-bloq",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "Common ESLint config used at Bloq",
   "keywords": [
     "bloq",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "next",
     "next.js",
     "node",
-    "typescript"
+    "typescript",
+    "vitest"
   ],
   "license": "MIT",
   "author": "Gabriel Montes <gabriel@bloq.com>",

--- a/vitest.js
+++ b/vitest.js
@@ -9,9 +9,6 @@ module.exports = {
     // equivalent to mocha/no-setup-in-describe
     '@vitest/require-hook': 'warn',
     // equivalent to mocha/no-skipped-tests
-    '@vitest/no-disabled-tests': 'error',
-    'no-unused-expressions': 'off',
-    'node/no-unpublished-require': 'warn',
-    'prefer-arrow/prefer-arrow-functions': 'off'
+    '@vitest/no-disabled-tests': 'error'
   }
 }

--- a/vitest.js
+++ b/vitest.js
@@ -4,14 +4,14 @@ module.exports = {
   extends: ['plugin:@vitest/legacy-recommended'],
   plugins: ['@vitest'],
   rules: {
+    // equivalent to mocha/no-exclusive-tests
+    '@vitest/no-focused-tests': 'error',
+    // equivalent to mocha/no-setup-in-describe
+    '@vitest/require-hook': 'warn',
+    // equivalent to mocha/no-skipped-tests
+    '@vitest/no-disabled-tests': 'error',
     'no-unused-expressions': 'off',
     'node/no-unpublished-require': 'warn',
-    'prefer-arrow/prefer-arrow-functions': 'off',
-    // equivalent to mocha/no-exclusive-tests
-    'vitest/no-focused-tests': 'error',
-    // equivalent to mocha/no-setup-in-describe
-    'vitest/require-hook': 'warn',
-    // equivalent to mocha/no-skipped-tests
-    'vitest/no-disabled-tests': 'error'
+    'prefer-arrow/prefer-arrow-functions': 'off'
   }
 }

--- a/vitest.js
+++ b/vitest.js
@@ -4,11 +4,11 @@ module.exports = {
   extends: ['plugin:@vitest/legacy-recommended'],
   plugins: ['@vitest'],
   rules: {
+    // equivalent to mocha/no-skipped-tests
+    '@vitest/no-disabled-tests': 'error',
     // equivalent to mocha/no-exclusive-tests
     '@vitest/no-focused-tests': 'error',
     // equivalent to mocha/no-setup-in-describe
-    '@vitest/require-hook': 'warn',
-    // equivalent to mocha/no-skipped-tests
-    '@vitest/no-disabled-tests': 'error'
+    '@vitest/require-hook': 'warn'
   }
 }


### PR DESCRIPTION
The Vitest configuration has 2 errors:

- By using the legacy configuration of Eslint, the rules need to be prepended with `@vitest/` instead of `vitest`. This wasn't in the docs, and if not using the appropriate prefix, it gives an error of missing definition of rule. (I created an issue in their repo to improve the docs about this https://github.com/vitest-dev/eslint-plugin-vitest/issues/566)

- The config was disabling some rules that did not belong to the `vitest` plugin, but were from `bloq/node`. Commonly, with `mocha`, we would use `bloq/node` before `bloq/mocha`, which causes those rules to be available. We tried to replicate that here, but as I am using `esm`, we can't use some of the rules from `bloq/node`. By not including it, these rules are not defined, throwing an error as well. The correct behavior should be that every package should only disable rules from the config it extends. That's why I am removing from the `vitest` config the following disabling of rules:

```
'no-unused-expressions'
'node/no-unpublished-require'
'prefer-arrow/prefer-arrow-functions'
```

As the vitest config did not work, I consider this a bug fix instead of a breaking change.