### PR TITLE
Rules improvements

### DIFF
--- a/esm.js
+++ b/esm.js
@@ -17,6 +17,7 @@ module.exports = {
         'newlines-between': 'always'
       }
     ],
+    'no-duplicate-imports': 'warn',
     'sort-imports': 'off'
   }
 }

--- a/next.js
+++ b/next.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   extends: ['next'],
-  ignorePatterns: ['out'],
+  ignorePatterns: ['.next', 'out'],
   parserOptions: {
     ecmaFeatures: {
       jsx: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-config-bloq",
-  "version": "4.6.1",
+  "version": "4.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-config-bloq",
-      "version": "4.6.1",
+      "version": "4.7.0",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^8.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-bloq",
-  "version": "4.6.1",
+  "version": "4.7.0",
   "description": "Common ESLint config used at Bloq",
   "keywords": [
     "bloq",

--- a/typescript.js
+++ b/typescript.js
@@ -1,5 +1,13 @@
 'use strict'
 
 module.exports = {
-  extends: ['plugin:@typescript-eslint/recommended']
+  extends: ['plugin:@typescript-eslint/recommended'],
+  rules: {
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {
+        ignoreRestSiblings: true
+      }
+    ]
+  }
 }


### PR DESCRIPTION
This PR addresses a few minor improvements:

- 4b0f046115fb6e7c69f063446e73b3d7a95b271d adds the [no-duplicate-imports](https://eslint.org/docs/latest/rules/no-duplicate-imports#rule-details) rule. This should prevent the following scenarios
 
```ts
import { a } from 'foo'
import { b } from 'foo'
```

forcing it to be

```ts
import { a, b } from 'foo'
```

This rule is native in Eslint - I enabled it as part of `bloq/esm`

- 4fa0a4e68fa719e2659b2c29ee1f97f7ceb80744 Adds `.next` folder in the `ignorePatterns` for `bloq/next`. Unsure why, but after upgrading to the latest version, the app would start lining this folder. It makes sense to ignore it as it's part of the build, just like the `out` folder

- 2116c70c104ff4dd06f9c351422bb5fe2e7d4ab7 Adds a typescript rule that we've been using in other repositories already - basically, extends `no-unused-vars` so it allows to spread with `...` and prevent that value from being considered unused. So for example

```ts
// if we no longer use "foo", it would be considered unused and warn, but it is there on purpose
// to allow creating a new object without this property
const { foo, ...rest } =  baz
console.log(rest)
```


The rule actually is from Eslint, but the extended version is used so it works with types


- 33ec8febb1b8d43d712ee464e5464105bcf7fbd4 bumps the version