### PR TITLE
Fix workflow name for npm-publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,5 +10,5 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: hemilabs/actions/.github/workflows/npm-publish.yml@c0d930f1959633dd7dc1203d95ec6634dbaf9a34 # v1.2.0
+    uses: hemilabs/.github/.github/workflows/npm-publish.yml@c0d930f1959633dd7dc1203d95ec6634dbaf9a34 # v1.2.0
     secrets: inherit


### PR DESCRIPTION
The referenced workflow for publishing was looking in the wrong repo...