### PR TITLE
Use react-hooks/recommended-legacy preset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-config-bloq",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-config-bloq",
-      "version": "4.8.0",
+      "version": "4.8.1",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^8.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-bloq",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "description": "Common ESLint config used at Bloq",
   "keywords": [
     "bloq",

--- a/react.js
+++ b/react.js
@@ -7,7 +7,7 @@ module.exports = {
   },
   extends: [
     'plugin:react/recommended',
-    'plugin:react-hooks/recommended',
+    'plugin:react-hooks/recommended-legacy',
     'plugin:jsx-a11y/recommended'
   ],
   parserOptions: {


### PR DESCRIPTION
## Summary

- Switch from `plugin:react-hooks/recommended` to `plugin:react-hooks/recommended-legacy` so the React config stays compatible with the eslintrc-style format used by this package (the default `recommended` preset in `eslint-plugin-react-hooks` v5+ ships as a flat config).
- Release as 4.8.1.

Closes #67