### PR TITLE
Add eqeqeq rule to enforce strict equality

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = {
     'complexity': ['warn', 10], // https://github.com/eslint/eslint/issues/4808
     'consistent-return': 'warn',
     'curly': ['warn', 'all'],
+    'eqeqeq': ['error', 'always'],
     'max-params': ['warn', 4],
     'new-cap': ['warn', { capIsNewExceptionPattern: '^Big$' }],
     'no-alert': 'warn',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-config-bloq",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-config-bloq",
-      "version": "4.8.1",
+      "version": "4.8.2",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^8.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-bloq",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "description": "Common ESLint config used at Bloq",
   "keywords": [
     "bloq",


### PR DESCRIPTION
### Description

Enables the core `eqeqeq` rule in the base config (`index.js`), configured as `['error', 'always']`. It was previously absent — `eqeqeq` is not part of `eslint:recommended`, so loose `==`/`!=` went unflagged in every consumer.

Placed in `index.js` rather than `typescript.js`/`esm.js`/`node.js` because it's language-agnostic and `index.js` is the shared base every consumer extends — so it covers all environments (node, esm, typescript, next) and both JS and TS in one line.

Bumps version to 4.8.2.

**Commits:**

114934a Add eqeqeq rule to enforce strict equality
bbb73a7 4.8.2
